### PR TITLE
Ensure we walk the whole tree replacing references

### DIFF
--- a/src/test/resources/integration-tests/array-ref-def.avsc
+++ b/src/test/resources/integration-tests/array-ref-def.avsc
@@ -1,0 +1,41 @@
+{
+  "type": "record",
+  "name": "ArrayDefRef",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "Account",
+      "type": {
+        "type": "record",
+        "name": "Account",
+        "fields": [
+          {
+            "name": "subject",
+            "doc": "Identifies the entity which incurs the expenses. While the immediate recipients of services or goods might be entities related to the subject, the expenses were ultimately incurred by the subject of the Account.",
+            "type": [
+              "null",
+              {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "Reference",
+                  "fields": [
+                    {
+                      "name": "id",
+                      "type": [
+                        "null",
+                        "string"
+                      ],
+                      "default": null
+                    }
+                  ]
+                }
+              }
+            ],
+            "default": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/integration-tests/array-ref-def.json
+++ b/src/test/resources/integration-tests/array-ref-def.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.org/ArrayDefRef",
+  "definitions": {
+    "Reference": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "Account": {
+      "properties": {
+        "subject": {
+          "description": "Identifies the entity which incurs the expenses. While the immediate recipients of services or goods might be entities related to the subject, the expenses were ultimately incurred by the subject of the Account.",
+          "items": {
+            "$ref": "#/definitions/Reference"
+          },
+          "type": "array"
+        }
+      }
+    }
+  }
+}

--- a/src/test/resources/integration-tests/nestedUnionRefs.avsc
+++ b/src/test/resources/integration-tests/nestedUnionRefs.avsc
@@ -1,0 +1,53 @@
+{
+  "type": "record",
+  "name": "NestedUnionRefs",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "value",
+      "type": [
+          {
+          "type": "record",
+          "name": "Thing",
+          "fields": [
+            {
+              "name": "subject",
+              "doc": "Identifies the entity which incurs the expenses. While the immediate recipients of services or goods might be entities related to the subject, the expenses were ultimately incurred by the subject of the Account.",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "record",
+                    "name": "Referenced",
+                    "fields": [
+                      {
+                        "name": "id",
+                        "type": [
+                          "null",
+                          "string"
+                        ],
+                        "default": null
+                      }
+                    ]
+                  }
+                }
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "OtherThing",
+          "fields": [
+            {
+              "name": "foo",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/integration-tests/nestedUnionRefs.json
+++ b/src/test/resources/integration-tests/nestedUnionRefs.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.org/NestedUnionRefs",
+  "definitions": {
+    "Referenced": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "Thing": {
+      "properties": {
+        "subject": {
+          "description": "Identifies the entity which incurs the expenses. While the immediate recipients of services or goods might be entities related to the subject, the expenses were ultimately incurred by the subject of the Account.",
+          "items": {
+            "$ref": "#/definitions/Referenced"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "OtherThing": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "required": ["foo"]
+    }
+  },
+  "oneOf": [
+    { "$ref":  "#/definitions/Thing" },
+    { "$ref":  "#/definitions/OtherThing"}
+  ]
+}

--- a/src/test/scala/IntegrationTests.scala
+++ b/src/test/scala/IntegrationTests.scala
@@ -27,6 +27,8 @@ class IntegrationTests extends AnyFlatSpec with TableDrivenPropertyChecks with M
     "siblingRefWithId",
     "definitions",
     "oneof",
+    "array-ref-def",
+    "nestedUnionRefs",
   )
 
   it should "run integration tests" in forAll(tests) { name =>


### PR DESCRIPTION
Previously, we were only going one level deep.
When we replaced a reference to a definition,
we never checked to see if that def also referenced another definition.

My original attempt at this tried to process the definitions by finding
any references to them, and replacing it, removing the definition and
moving on, but that algorithm ended up being O(n^n).

The current algorithm does perform a lookup to see if any of the current
list of definitions are referenced, and we do recurse until none are
left, so this is definitely a brute force algorithm.
(I think it's O(n^2) or O(n^3), but I didn't take the time to actually analyze
it.)

There's room for improvement, but it does complete before the heat death
of the universe.