### PR TITLE
Sanitizes record names

### DIFF
--- a/src/main/scala/NameSanitizer.scala
+++ b/src/main/scala/NameSanitizer.scala
@@ -1,0 +1,37 @@
+package io.carrera.jsontoavroschema
+
+object NameSanitizer {
+  def sanitize(rootName: String)(record: AvroRecord): AvroRecord = {
+    val sanitizer = sanitizeName(rootName) _
+    sanitizeType(record, sanitizer).asInstanceOf[AvroRecord]
+  }
+
+  private def sanitizeField(field: AvroField, sanitizer: String => String): AvroField = {
+    field.copy(`type` = sanitizeType(field.`type`, sanitizer))
+  }
+
+  private def sanitizeType(avroType: AvroType, sanitizer: String => String): AvroType = {
+    avroType match {
+      case AvroRef(name) => AvroRef(sanitizer(name))
+      case AvroUnion(types) => AvroUnion(types.map(t => sanitizeType(t, sanitizer)))
+      case AvroArray(t) => AvroArray(sanitizeType(t, sanitizer))
+      case AvroMap(t) => AvroMap(sanitizeType(t, sanitizer))
+      case AvroRecord(name, ns, doc, fields) =>
+        AvroRecord(sanitizer(name), ns, doc, fields.map(fld => sanitizeField(fld, sanitizer)))
+      case t => t
+    }
+  }
+
+  private def sanitizeName(rootName: String)(name: String):String =
+    name match {
+      case "boolean" => s"${rootName}Boolean"
+      case "string" => s"${rootName}String"
+      case "int" => s"${rootName}Int"
+      case "long" => s"${rootName}Long"
+      case "float" => s"${rootName}Float"
+      case "double" => s"${rootName}Double"
+      case "bytes" => s"${rootName}Bytes"
+      case "null" => s"${rootName}Null"
+      case x => x
+    }
+}

--- a/src/test/scala/TranspilerSpec.scala
+++ b/src/test/scala/TranspilerSpec.scala
@@ -713,6 +713,44 @@ class TranspilerSpec extends AnyFlatSpec {
     avroSchema should be(expectedRecord)
   }
 
+  it should "sanitize names of boolean" in {
+    val root = JsonSchema.empty.copy(
+      id = schemaUri,
+      definitions = Map("boolean" -> Right(JsonSchema.empty.copy(types = Seq(JsonSchemaBool)))),
+      properties = Map("A" -> Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/boolean")))),
+      required = Seq("A")
+    )
+    val Right(avroSchema) = Transpiler.transpile(Right(root), None)
+
+    val expectedRecord =
+      AvroRecord("schema", None, None, Seq(
+        AvroField("A", None,
+          AvroRecord("schemaBoolean", None, None, Seq(AvroField("value", None, AvroBool, None, None)))
+          , None, None)
+      ))
+
+    avroSchema should be(expectedRecord)
+  }
+
+  it should "sanitize names of string" in {
+    val root = JsonSchema.empty.copy(
+      id = schemaUri,
+      definitions = Map("string" -> Right(JsonSchema.empty.copy(types = Seq(JsonSchemaString)))),
+      properties = Map("A" -> Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/string")))),
+      required = Seq("A")
+    )
+    val Right(avroSchema) = Transpiler.transpile(Right(root), None)
+
+    val expectedRecord =
+      AvroRecord("schema", None, None, Seq(
+        AvroField("A", None,
+          AvroRecord("schemaString", None, None, Seq(AvroField("value", None, AvroString, None, None)))
+          , None, None)
+      ))
+
+    avroSchema should be(expectedRecord)
+  }
+
   private def schemaUri =
     Uri.parseOption("http://json-schema.org/draft-06/schema#")
 }


### PR DESCRIPTION
JSON schema allows (and the FHIR schema defines)
naming things primitive types, e.g. string, boolean, etc.,
but AVRO disallows this and won't compile.
To solve this, we take the root schema name and preprend it to any names like this.

Fixes #38