### PR TITLE
Fixes #40 - Inlines depth first

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,5 +9,6 @@ idePackagePrefix := Some("io.carrera.jsontoavroschema")
 libraryDependencies += "com.lihaoyi" %% "upickle" % "1.2.3"
 libraryDependencies += "io.lemonlabs" % "scala-uri_2.13" % "3.0.0"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % Test
+libraryDependencies += "com.lihaoyi" %% "pprint" % "0.6.4" % Test
 
 scalacOptions += "-Werror"

--- a/src/test/resources/integration-tests/array-ref-def.avsc
+++ b/src/test/resources/integration-tests/array-ref-def.avsc
@@ -4,10 +4,10 @@
   "namespace": "com.example",
   "fields": [
     {
-      "name": "Account",
+      "name": "ArrayHolder",
       "type": {
         "type": "record",
-        "name": "Account",
+        "name": "ArrayHolder",
         "fields": [
           {
             "name": "subject",

--- a/src/test/resources/integration-tests/array-ref-def.json
+++ b/src/test/resources/integration-tests/array-ref-def.json
@@ -11,7 +11,7 @@
     }
   },
   "properties": {
-    "Account": {
+    "ArrayHolder": {
       "properties": {
         "subject": {
           "description": "Identifies the entity which incurs the expenses. While the immediate recipients of services or goods might be entities related to the subject, the expenses were ultimately incurred by the subject of the Account.",

--- a/src/test/resources/integration-tests/selfref.avsc
+++ b/src/test/resources/integration-tests/selfref.avsc
@@ -1,0 +1,99 @@
+{
+  "type": "record",
+  "name": "SelfReferencing",
+  "namespace":"com.example",
+  "fields": [
+    {
+      "name": "value",
+      "type": [
+        {
+          "type": "record",
+          "name": "Account",
+          "fields": [
+            {
+              "name": "language",
+              "doc": "The base language in which the resource is written.",
+              "type": [
+                "null",
+                "string"
+              ],
+              "default": null
+            },
+            {
+              "name": "_language",
+              "doc":"Extensions for language",
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "Element",
+                  "fields": [
+                    {
+                      "name": "extension",
+                      "type": [
+                        "null",
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "record",
+                            "name": "Extension",
+                            "fields": [
+                              {
+                                "name": "extension",
+                                "type": [
+                                  "null",
+                                  {
+                                    "type": "array",
+                                    "items": "Extension"
+                                  }
+                                ],
+                                "default": null
+                              },
+                              {
+                                "name": "circularRef",
+                                "type": [
+                                  "null",
+                                  "Element"
+                                ],
+                                "default": null
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "default": null
+                    }
+                  ]
+                }
+              ],
+              "default": null
+            },
+            {
+              "name": "extension",
+              "doc": "May be used to represent additional information that is not part of the basic definition of the resource.",
+              "type": [
+                "null",
+                {
+                  "type": "array",
+                  "items": "Extension"
+                }
+              ],
+              "default": null
+            }
+          ]
+        },
+        {
+          "type": "record",
+          "name": "DifferentThing",
+          "fields": [
+            {
+              "name": "foo",
+              "type": ["null", "boolean"],
+              "default": null
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/integration-tests/selfref.json
+++ b/src/test/resources/integration-tests/selfref.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "$id": "http://example.org/SelfReferencing",
+  "definitions": {
+    "Element": {
+      "properties": {
+        "extension": {
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Extension": {
+      "properties": {
+        "extension": {
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        },
+        "circularRef": {
+          "$ref": "#/definitions/Element"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Account": {
+      "properties": {
+        "language": {
+          "description": "The base language in which the resource is written.",
+          "type": "string"
+        },
+        "_language": {
+          "description": "Extensions for language",
+          "$ref": "#/definitions/Element"
+        },
+        "extension": {
+          "description": "May be used to represent additional information that is not part of the basic definition of the resource.",
+          "items": {
+            "$ref": "#/definitions/Extension"
+          },
+          "type": "array"
+        }
+      }
+    },
+    "DifferentThing": {
+      "properties": {
+        "foo": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref":  "#/definitions/Account" },
+    { "$ref":  "#/definitions/DifferentThing"}
+  ]
+}

--- a/src/test/scala/IntegrationTests.scala
+++ b/src/test/scala/IntegrationTests.scala
@@ -29,6 +29,7 @@ class IntegrationTests extends AnyFlatSpec with TableDrivenPropertyChecks with M
     "oneof",
     "array-ref-def",
     "nestedUnionRefs",
+    "selfref",
   )
 
   it should "run integration tests" in forAll(tests) { name =>

--- a/src/test/scala/TranspilerSpec.scala
+++ b/src/test/scala/TranspilerSpec.scala
@@ -649,6 +649,67 @@ class TranspilerSpec extends AnyFlatSpec {
     avroSchema should equal(expectedRecord)
   }
 
+  it should "properly inline defs given a complex graph of self and circular references" in {
+    val extension = Right(JsonSchema.empty.copy(
+      types = Seq(JsonSchemaArray),
+      items = Seq(Right(JsonSchema.empty.copy(ref =  Uri.parseOption("#/definitions/Extension"))))
+    ))
+
+    val root = JsonSchema.empty.copy(
+      id = schemaUri,
+      definitions = Map(
+        "Element" -> Right(JsonSchema.empty.copy(
+          properties = Map("extension" -> extension),
+          required = Seq("extension")
+        )),
+        "Extension" -> Right(JsonSchema.empty.copy(
+          properties = Map(
+            "extension" -> extension,
+            "elem" -> Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/Element")))
+          ),
+          required = Seq("extension", "elem")
+        )),
+        "Account" -> Right(JsonSchema.empty.copy(
+          properties = Map(
+            "_language" -> Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/Element"))),
+            "extension" -> extension
+          ),
+          required = Seq("_language", "extension")
+        ))
+      ),
+      oneOf = Seq(
+        Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/Account"))),
+        Right(JsonSchema.empty.copy(types = Seq(JsonSchemaString)))
+      )
+    )
+
+    val Right(avroSchema) = Transpiler.transpile(Right(root), None)
+
+    val expectedRecord =
+      AvroRecord("schema", None, None, Seq(
+        AvroField("value", None,
+          AvroUnion(Seq(
+            AvroRecord("Account", None, None, Seq(
+              AvroField("_language", None,
+                AvroRecord("Element", None, None, Seq(
+                  AvroField("extension", None,
+                    AvroArray(AvroRecord("Extension", None, None, Seq(
+                      AvroField("extension", None, AvroArray(AvroRef("Extension")), None, None),
+                      AvroField("elem", None, AvroRef("Element"), None, None)
+                    ))),
+                    None, None)
+                )),
+                None, None),
+              AvroField("extension", None, AvroArray(AvroRef("Extension")), None, None)
+            )),
+            AvroString,
+          ))
+          ,None, None)
+      ))
+
+    avroSchema should be(expectedRecord)
+  }
+
   it should "transpile oneOf at root" in {
     val root =
       JsonSchema.empty.copy(

--- a/src/test/scala/TranspilerSpec.scala
+++ b/src/test/scala/TranspilerSpec.scala
@@ -652,7 +652,7 @@ class TranspilerSpec extends AnyFlatSpec {
   it should "properly inline defs given a complex graph of self and circular references" in {
     val extension = Right(JsonSchema.empty.copy(
       types = Seq(JsonSchemaArray),
-      items = Seq(Right(JsonSchema.empty.copy(ref =  Uri.parseOption("#/definitions/Extension"))))
+      items = Seq(Right(JsonSchema.empty.copy(ref = Uri.parseOption("#/definitions/Extension"))))
     ))
 
     val root = JsonSchema.empty.copy(


### PR DESCRIPTION
Previously, we checked each field for references.
This resulted in definitions being inlined _after_ their first reference
when an inlined definition referenced another def that needed to be
inlined.

Fixed by recursing into the freshly inlined/resolved type looking for
more replacements to be made.

i.e. now we do a depth first instead of breadth first search