### PR TITLE
Closes #42: More unique enum names

### DIFF
--- a/src/test/resources/integration-tests/stringEnum.avsc
+++ b/src/test/resources/integration-tests/stringEnum.avsc
@@ -7,8 +7,27 @@
       "name": "someProp",
       "type": {
         "type": "enum",
-        "name": "somePropEnum",
+        "name": "StringEnum_someProp",
         "symbols": ["a", "b"]
+      }
+    },
+    {
+      "name": "otherProp",
+      "type": {
+        "type": "record",
+        "name": "otherProp",
+        "fields": [
+          {
+            "name": "enumProp",
+            "type": {
+              "type": "enum",
+              "name": "otherProp_enumProp",
+              "symbols": [
+                "foo"
+              ]
+            }
+          }
+        ]
       }
     }
   ]

--- a/src/test/resources/integration-tests/stringEnum.json
+++ b/src/test/resources/integration-tests/stringEnum.json
@@ -7,7 +7,15 @@
           "a",
           "b"
       ]
+    },
+    "otherProp": {
+      "properties": {
+        "enumProp": {
+          "enum": ["foo"]
+        }
+      },
+      "required": ["enumProp"]
     }
   },
-  "required": ["someProp"]
+  "required": ["someProp", "otherProp"]
 }

--- a/src/test/scala/TranspilerSpec.scala
+++ b/src/test/scala/TranspilerSpec.scala
@@ -247,7 +247,7 @@ class TranspilerSpec extends AnyFlatSpec {
 
     val expectedRecord =
       AvroRecord("schema", None, None,
-        Seq(AvroField("someProp", None, AvroEnum("somePropEnum", Seq("a","b")), None, None))
+        Seq(AvroField("someProp", None, AvroEnum("schema_someProp", Seq("a","b")), None, None))
       )
 
     avro should be(expectedRecord)
@@ -274,7 +274,7 @@ class TranspilerSpec extends AnyFlatSpec {
 
     val expectedRecord =
       AvroRecord("schema", None, None,
-        Seq(AvroField("someProp", None, AvroEnum("somePropEnum",
+        Seq(AvroField("someProp", None, AvroEnum("schema_someProp",
           Seq("a_thing_a_ma_bob", "text_cql", "Some_thing", "LT", "LTEq", "GTEq", "GT", "Eq")),
           None, None
         ))


### PR DESCRIPTION
Enum names still aren't guaranteed to be unique,
but the chances that they are is much greater now.
They're certainly unique enough to process the FHIR schema,
which uses the same names often.